### PR TITLE
refactor: Implement Help link and refine UI styling

### DIFF
--- a/dehix_alpha_frontend-main/src/components/shared/ChatLayout.tsx
+++ b/dehix_alpha_frontend-main/src/components/shared/ChatLayout.tsx
@@ -32,7 +32,7 @@ const ChatLayout: React.FC<ChatLayoutProps> = ({ chatListComponent, chatWindowCo
       <Panel defaultSize={25} minSize={20} maxSize={40} collapsible={true} collapsedSize={0} id="chat-sidebar-panel" className="h-full">
         <aside
           className={cn(
-            "h-full bg-[hsl(var(--card))] p-4 overflow-y-auto shadow-md dark:shadow-none", // Added shadow for light mode
+            "h-full bg-[hsl(var(--card))] p-4 overflow-y-auto shadow-lg dark:shadow-none", // Changed shadow-md to shadow-lg for light mode
             // Original responsive hiding logic is no longer needed here as Panel can be collapsed.
             // Or, if we want to hide it by default on small screens even when not "expanded":
             // "hidden md:flex flex-col h-full"

--- a/dehix_alpha_frontend-main/src/components/shared/chat.tsx
+++ b/dehix_alpha_frontend-main/src/components/shared/chat.tsx
@@ -18,9 +18,12 @@ import {
   CheckCheck,
   Flag, // Added
   HelpCircle, // Added
+  Flag,
+  HelpCircle,
 } from 'lucide-react';
 import { useSelector } from 'react-redux';
 import { DocumentData } from 'firebase/firestore';
+import { useRouter } from 'next/navigation'; // Added
 import ReactMarkdown from 'react-markdown'; // Import react-markdown to render markdown
 import {
   formatDistanceToNow,
@@ -115,9 +118,10 @@ export function CardsChat({
   conversation,
   conversations,
   setActiveConversation,
-  isChatExpanded, // Added
-  onToggleExpand, // Added
+  isChatExpanded,
+  onToggleExpand,
 }: CardsChatProps) {
+  const router = useRouter(); // Added
   const [primaryUser, setPrimaryUser] = useState<User>({
     userName: '',
     email: '',
@@ -410,8 +414,8 @@ export function CardsChat({
           <LoaderCircle className="h-6 w-6 text-white animate-spin" />
         </div>
       ) : (
-        <Card className="col-span-3 flex flex-col h-full bg-[hsl(var(--background))] shadow-none border-none">
-          <CardHeader className="flex flex-row items-center justify-between bg-[hsl(var(--card))] text-[hsl(var(--card-foreground))] p-3 border-b border-[hsl(var(--border))] shadow-sm dark:shadow-none">
+        <Card className="col-span-3 flex flex-col h-full bg-[hsl(var(--background))] shadow-lg dark:shadow-none border-none">
+          <CardHeader className="flex flex-row items-center justify-between bg-[hsl(var(--card))] text-[hsl(var(--card-foreground))] p-3 border-b border-[hsl(var(--border))] shadow-md dark:shadow-none">
             <div className="flex items-center space-x-3">
               <Avatar className="w-10 h-10">
                 <AvatarImage src={primaryUser.profilePic} alt={primaryUser.userName || 'User'} />
@@ -448,7 +452,9 @@ export function CardsChat({
                     <Flag className="mr-2 h-4 w-4 text-[hsl(var(--muted-foreground))]" />
                     <span>Report</span>
                   </DropdownMenuItem>
-                  <DropdownMenuItem onSelect={() => console.log('Help option clicked')} className="hover:!bg-[hsl(var(--accent))] focus:!bg-[hsl(var(--accent))] text-[hsl(var(--popover-foreground))] focus:text-[hsl(var(--accent-foreground))]">
+                  <DropdownMenuItem
+                    onSelect={() => router.push('http://localhost:3000/settings/support')}
+                    className="hover:!bg-[hsl(var(--accent))] focus:!bg-[hsl(var(--accent))] text-[hsl(var(--popover-foreground))] focus:text-[hsl(var(--accent-foreground))]">
                     <HelpCircle className="mr-2 h-4 w-4 text-[hsl(var(--muted-foreground))]" />
                     <span>Help</span>
                   </DropdownMenuItem>
@@ -456,7 +462,7 @@ export function CardsChat({
               </DropdownMenu>
             </div>
           </CardHeader>
-          <CardContent className="flex-1 overflow-y-auto p-4 bg-[hsl(var(--background))]"> {/* p-4 for padding, flex-1 and overflow for scrolling */}
+          <CardContent className="flex-1 overflow-y-auto p-4 bg-[hsl(var(--background))]">
             <div className="flex flex-col-reverse space-y-3 space-y-reverse">
               <div ref={messagesEndRef} />
               {messages.map((message, index) => {
@@ -564,7 +570,7 @@ export function CardsChat({
               })}
             </div>
           </CardContent>
-          <CardFooter className="bg-[hsl(var(--card))] p-2 border-t border-[hsl(var(--border))] shadow-sm dark:shadow-none">
+          <CardFooter className="bg-[hsl(var(--card))] p-2 border-t border-[hsl(var(--border))] shadow-md dark:shadow-none">
             <form
               onSubmit={(event) => {
                 event.preventDefault();

--- a/dehix_alpha_frontend-main/src/components/shared/chatList.tsx
+++ b/dehix_alpha_frontend-main/src/components/shared/chatList.tsx
@@ -134,7 +134,7 @@ export function ChatList({
   });
 
   return (
-    <div className="flex flex-col h-full bg-[hsl(var(--card))]"> {/* Use card color for sidebar bg */}
+    <div className="flex flex-col h-full bg-[hsl(var(--card))]">
       {/* New Chat Button and Search Bar Area */}
       <div className="p-3 border-b border-[hsl(var(--border))]">
         {/* New "Create Group Chat" Button - "New Chat" dropdown removed as it became empty */}
@@ -226,10 +226,10 @@ export function ChatList({
 
       {showCreateGroupDialog && (
         <Dialog open={showCreateGroupDialog} onOpenChange={setShowCreateGroupDialog}>
-          <DialogContent className="sm:max-w-[450px] bg-[hsl(var(--card))] text-[hsl(var(--card-foreground))] border-[hsl(var(--border))]">
+          <DialogContent className="sm:max-w-[450px] bg-[hsl(var(--card))] text-[hsl(var(--card-foreground))] border-[hsl(var(--border))] shadow-xl"> {/* Added shadow-xl */}
             <DialogHeader>
               <DialogTitle className="text-[hsl(var(--card-foreground))]">Create a group chat</DialogTitle>
-              <DialogDescription className="text-[hsl(var(--muted-foreground))] pt-1"> {/* Added small top padding to description */}
+              <DialogDescription className="text-[hsl(var(--muted-foreground))] pt-1">
                 Fill in the details below to start a new group conversation.
               </DialogDescription>
             </DialogHeader>


### PR DESCRIPTION
This commit addresses your feedback by:

1.  **Making "Help" Menu Option Functional:**
    *   The "Help" option in the "More options" (3-dot) menu within the chat header (`chat.tsx`) now navigates to `http://localhost:3000/settings/support` using Next.js router.

2.  **Refining UI Styling:**
    *   **Enhanced Light Mode Shadows:** Increased shadow intensity on key UI elements (main chat window card, chat header, chat footer, and sidebar) in light mode for better visual separation and depth. Dark mode shadow behavior (typically `dark:shadow-none`) is preserved.
    *   **"Create Group Chat" Modal Polish:**
        *   Added `shadow-xl` to the `DialogContent` of the "Create Group Chat" modal in `chatList.tsx` for better elevation.
        *   Verified and confirmed existing internal padding and spacing within the modal are sufficient after previous adjustments.
    *   **Message Input Visibility:** Re-confirmed that the message input area remains fixed at the bottom of the chat window.

These changes improve UI navigation and visual polish based on your specific requests.